### PR TITLE
Add special case for 'n'

### DIFF
--- a/src/guessUnicodePunctuation.js
+++ b/src/guessUnicodePunctuation.js
@@ -2,6 +2,7 @@ import { transformInputValues } from "./transformInputValues";
 
 const transformationRules = [
 	[/(?<=\W|^)"(.+?)"(?=\W|$)/g, '“$1”'], // double quoted text
+	[/(?<=\W|^)'n'(?=\W|$)/g, '’n’'], // special case: 'n'
 	[/(?<=\W|^)'(.+?)'(?=\W|$)/g, '‘$1’'], // single quoted text
 	// ... which is enclosed by non-word characters or at the beginning/end of the title
 	[/(\d+)"/g, '$1″'], // double primes, e.g. for 12″


### PR DESCRIPTION
I've ran into this little bugger a couple of times and it's incorrectly converted into `‘n’`. I've added a special case before the usual processing of balanced `'`s since that's (probably) the easiest way to fix it.

I was a bit reluctant though, since the potential for special casing is near-infinite, but I think this case is common enough to warrant it.

Tested on https://test.musicbrainz.org/release/71d7aa3d-17d5-47e2-9a73-be4ac4e6a011 and everything else still works as it should.