### PR TITLE
Punctuation: Make special case 'n' case-insensitive

### DIFF
--- a/src/guessUnicodePunctuation.js
+++ b/src/guessUnicodePunctuation.js
@@ -2,7 +2,7 @@ import { transformInputValues } from './transformInputValues';
 
 export const transformationRules = [
 	[/(?<=\W|^)"(.+?)"(?=\W|$)/g, '“$1”'], // double quoted text
-	[/(?<=\W|^)'n'(?=\W|$)/g, '’n’'], // special case: 'n'
+	[/(?<=\W|^)'(n)'(?=\W|$)/ig, '’$1’'], // special case: 'n'
 	[/(?<=\W|^)'(.+?)'(?=\W|$)/g, '‘$1’'], // single quoted text
 	// ... which is enclosed by non-word characters or at the beginning/end of the title
 	[/(\d+)"/g, '$1″'], // double primes, e.g. for 12″


### PR DESCRIPTION
Continuation of #6.

If you Guess Punctuation before Guess Case, an `'N'` will get converted to `‘N’` and ignored by Guess Case.

I’ll fix the ones that have been incorrectly converted in the past.

Still haven’t found the time to set up npm, so please build the bookmarklet/userscript, apologies! 🙂 